### PR TITLE
[Live Share] Allow developers to specify a profile to use when hosting Live Share sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-profile-switcher",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1782,6 +1782,11 @@
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.1"
 			}
+		},
+		"vsls": {
+			"version": "0.3.1291",
+			"resolved": "https://registry.npmjs.org/vsls/-/vsls-0.3.1291.tgz",
+			"integrity": "sha512-8yJPN9p7k+XYyczOVtQmpun4K1CRDsw/hdnIzT/c40r5bIkpptfsBlHmmLemoIV+CAHvrTLdWKEf5OtRvdcn9A=="
 		},
 		"which": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
         "title": "Profile Switcher: Select Profile"
       },
       {
+        "command": "extension.selectLiveShareProfile",
+        "title": "Profile Switcher: Select Live Share Profile"
+      },
+      {
         "command": "extension.saveProfile",
         "title": "Profile Switcher: Save Profile"
       },
@@ -73,6 +77,11 @@
               "type": "object"
             }
           }
+        },
+        "profileSwitcher.liveShareProfile": {
+          "type": "string",
+          "description": "Specifies the profile you'd like to use when you start a Live Share session. Defaults to using the current profile",
+          "default": null
         },
         "profileSwitcher.extensions": {
           "type": "object",
@@ -124,6 +133,7 @@
     "vscode": "^1.1.28"
   },
   "dependencies": {
-    "fs-extra": "^8.0.1"
+    "fs-extra": "^8.0.1",
+    "vsls": "^0.3.1291"
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 enum ContributedCommands {
+  SelectLiveShareProfile = "extension.selectLiveShareProfile",
   SelectProfile = "extension.selectProfile",
   SaveProfile = "extension.saveProfile",
   DeleteProfile = "extension.deleteProfile"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,10 @@ export const ExtensionName = "vscode-profile-switcher";
 export const ExtensionPublisher = "aaronpowell";
 export const ExtensionId = `${ExtensionPublisher}.${ExtensionName}`;
 
+export const ContextSettingCurrentProfile = "currentProfile";
+export const ContextSettingPreviousProfile = "previousProfile";
+
+export const ConfigLiveShareProfileKey = "liveShareProfile";
 export const ConfigKey = "profileSwitcher";
 export const ConfigProfilesKey = "profiles";
 export const ConfigStorageKey = "storage";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ async function activateProfile(
 ) {
   let msg = vscode.window.setStatusBarMessage("Switching profiles.");
 
-  config.setCurrentProfile(profile);
+  await config.setCurrentProfile(profile);
 
   let profileSettings = config.getProfileSettings(profile);
   await settingsHelper.updateUserSettings(profileSettings);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,53 @@ import SettingsHelper from "./settingsHelper";
 import ContributedCommands from "./commands";
 import Config from "./services/config";
 import ExtensionHelper from "./services/extensions";
+import * as liveShare from "./services/liveShare";
+
+async function activateProfile(
+  profile: string,
+  config: Config,
+  settingsHelper: SettingsHelper,
+  extensionsHelper: ExtensionHelper
+) {
+  let msg = vscode.window.setStatusBarMessage("Switching profiles.");
+
+  config.setCurrentProfile(profile);
+
+  let profileSettings = config.getProfileSettings(profile);
+  await settingsHelper.updateUserSettings(profileSettings);
+
+  let extensions = config.getProfileExtensions(profile);
+  await extensionsHelper.installExtensions(extensions);
+  await extensionsHelper.removeExtensions(extensions);
+
+  msg.dispose();
+
+  const message = await vscode.window.showInformationMessage(
+    "Do you want to reload and activate the extensions?",
+    "Yes"
+  );
+
+  if (message === "Yes") {
+    vscode.commands.executeCommand("workbench.action.reloadWindow");
+  }
+}
+
+async function promptProfile(config: Config): Promise<string | undefined> {
+  let profiles = config.getProfiles();
+
+  if (!profiles.length) {
+    await vscode.window.showInformationMessage(
+      "There are no profiles saved to switch to. First save a profile and then you can pick it"
+    );
+    return;
+  }
+
+  let profile = await vscode.window.showQuickPick(profiles, {
+    placeHolder: "Select a profile"
+  });
+
+  return profile;
+}
 
 function selectProfile(
   config: Config,
@@ -10,42 +57,23 @@ function selectProfile(
   extensionsHelper: ExtensionHelper
 ) {
   return async () => {
-    let profiles = config.getProfiles();
-
-    if (!profiles.length) {
-      await vscode.window.showInformationMessage(
-        "There are no profiles saved to switch to. First save a profile and then you can pick it"
-      );
-      return;
-    }
-
-    let profile = await vscode.window.showQuickPick(profiles, {
-      placeHolder: "Select a profile"
-    });
-
+    const profile = await promptProfile(config);
     if (!profile) {
       return;
     }
 
-    let msg = vscode.window.setStatusBarMessage("Switching profiles.");
+    activateProfile(profile, config, settingsHelper, extensionsHelper);
+  };
+}
 
-    let profileSettings = config.getProfileSettings(profile);
-    await settingsHelper.updateUserSettings(profileSettings);
-
-    let extensions = config.getProfileExtensions(profile);
-    await extensionsHelper.installExtensions(extensions);
-    await extensionsHelper.removeExtensions(extensions);
-
-    msg.dispose();
-
-    const message = await vscode.window.showInformationMessage(
-      "Do you want to reload and activate the extensions?",
-      "Yes"
-    );
-
-    if (message === "Yes") {
-      vscode.commands.executeCommand("workbench.action.reloadWindow");
+function selectLiveShareProfile(config: Config) {
+  return async () => {
+    const profile = await promptProfile(config);
+    if (!profile) {
+      return;
     }
+
+    await config.setLiveShareProfile(profile);
   };
 }
 
@@ -117,9 +145,16 @@ function deleteProfile(config: Config) {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  let config = new Config();
+  let config = new Config(context);
   let settingsHelper = new SettingsHelper(context);
   let extensionsHelper = new ExtensionHelper(context, settingsHelper, config);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      ContributedCommands.SelectLiveShareProfile,
+      selectLiveShareProfile(config)
+    )
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -141,4 +176,8 @@ export async function activate(context: vscode.ExtensionContext) {
       deleteProfile(config)
     )
   );
+
+  liveShare.initialize(context, config, (profile: string) => {
+    activateProfile(profile, config, settingsHelper, extensionsHelper);
+  });
 }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -42,12 +42,12 @@ class Config {
     return config.update(ConfigLiveShareProfileKey, profile, vscode.ConfigurationTarget.Global);
   }
 
-  public setCurrentProfile(profile: string) {
+  public async setCurrentProfile(profile: string) {
     if (this.context) {
       const previousProfile = this.context.globalState.get<string>(ContextSettingCurrentProfile);
       this.setPreviousProfile(previousProfile);
 
-      this.context.globalState.update(ContextSettingCurrentProfile, profile);
+      await this.context.globalState.update(ContextSettingCurrentProfile, profile);
     }
   }
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -4,7 +4,10 @@ import {
   ConfigProfilesKey,
   ConfigStorageKey,
   ConfigExtensionsKey,
-  ConfigExtensionsIgnoreKey
+  ConfigExtensionsIgnoreKey,
+  ConfigLiveShareProfileKey,
+  ContextSettingCurrentProfile,
+  ContextSettingPreviousProfile
 } from "../constants";
 import { ExtensionInfo } from "./extensions";
 
@@ -21,8 +24,39 @@ interface ExtensionStorage {
 }
 
 class Config {
+  constructor(private context?: vscode.ExtensionContext) {}
+
   private getConfig() {
     return vscode.workspace.getConfiguration(ConfigKey);
+  }
+
+  public getLiveShareProfile() {
+    let config = this.getConfig();
+
+    return config.get<string | null>(ConfigLiveShareProfileKey, null);
+  }
+
+  public setLiveShareProfile(profile: string) {
+    let config = this.getConfig();
+
+    return config.update(ConfigLiveShareProfileKey, profile, vscode.ConfigurationTarget.Global);
+  }
+
+  public setCurrentProfile(profile: string) {
+    if (this.context) {
+      const previousProfile = this.context.globalState.get<string>(ContextSettingCurrentProfile);
+      this.setPreviousProfile(previousProfile);
+
+      this.context.globalState.update(ContextSettingCurrentProfile, profile);
+    }
+  }
+
+  public getPreviousProfile(): string | undefined {
+    return this.context && this.context.globalState.get(ContextSettingPreviousProfile);
+  }
+
+  public setPreviousProfile(profile: string | undefined) {
+    this.context && this.context.globalState.update(ContextSettingPreviousProfile, profile);
   }
 
   public getProfiles() {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -24,7 +24,7 @@ interface ExtensionStorage {
 }
 
 class Config {
-  constructor(private context?: vscode.ExtensionContext) {}
+  public constructor(private context?: vscode.ExtensionContext) {}
 
   private getConfig() {
     return vscode.workspace.getConfiguration(ConfigKey);

--- a/src/services/liveShare.ts
+++ b/src/services/liveShare.ts
@@ -12,17 +12,12 @@ export async function initialize(
         return;
     }
 
-    const liveShareProfile = config.getLiveShareProfile();
-    if (!liveShareProfile) {
-        return;
-    }
-
-    // Check to see whether there was a lingering profile set
-    // (e.g. because the user closed VS Code while in a Live Share
-    // session), and if so, restore the right profile.
-    restorePreviousProfile(config, activateProfileHandler);
-
     liveShare.onDidChangeSession(e => {
+        const liveShareProfile = config.getLiveShareProfile();
+        if (!liveShareProfile) {
+            return;
+        }
+
         if (e.session.id) {
             activateProfileHandler(liveShareProfile);
         } else {

--- a/src/services/liveShare.ts
+++ b/src/services/liveShare.ts
@@ -7,18 +7,27 @@ export async function initialize(
     config: Config,
     activateProfileHandler: (profile: string) => void
 ) {
+    // Check to see if the end-user has the Live Share 
+    // extension installed, and if not, exit early.
     const liveShare = await vsls.getApi();
     if (!liveShare) {
         return;
     }
 
+    // Begin listening for the beginning and end of Live
+    // Share sessions, in case we need to switch profiles.
     liveShare.onDidChangeSession(e => {
-        if (e.session.id) {
-            const liveShareProfile = config.getLiveShareProfile();
-            if (!liveShareProfile) {
-                return;
-            }
+        // If the end-user never set a Live Share profile, then
+        // there's nothing we need to do. Note that we're calling
+        // this here, instead of as part of the activation flow,
+        // so that the end-user can set their profile any time
+        // and have it take effect immediately.
+        const liveShareProfile = config.getLiveShareProfile();
+        if (!liveShareProfile) {
+            return;
+        }
 
+        if (e.session.id) {
             activateProfileHandler(liveShareProfile);
         } else {
             const previousProfile = config.getPreviousProfile();

--- a/src/services/liveShare.ts
+++ b/src/services/liveShare.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+import * as vsls from "vsls";
+import Config from "./config";
+
+export async function initialize(
+    context: vscode.ExtensionContext,
+    config: Config,
+    activateProfileHandler: (profile: string) => void
+) {
+    const liveShare = await vsls.getApi();
+    if (!liveShare) {
+        return;
+    }
+
+    const liveShareProfile = config.getLiveShareProfile();
+    if (!liveShareProfile) {
+        return;
+    }
+
+    // Check to see whether there was a lingering profile set
+    // (e.g. because the user closed VS Code while in a Live Share
+    // session), and if so, restore the right profile.
+    restorePreviousProfile(config, activateProfileHandler);
+
+    liveShare.onDidChangeSession(e => {
+        if (e.session.id) {
+            activateProfileHandler(liveShareProfile);
+        } else {
+            restorePreviousProfile(config, activateProfileHandler);
+        }
+    })
+}
+
+function restorePreviousProfile(
+    config: Config,
+    activateProfileHandler: (profile: string) => void
+) {
+    const previousProfile = config.getPreviousProfile();
+    if (!previousProfile) {
+        return;
+    }
+
+    config.setPreviousProfile(undefined);
+    activateProfileHandler(previousProfile);
+}

--- a/src/services/liveShare.ts
+++ b/src/services/liveShare.ts
@@ -13,28 +13,21 @@ export async function initialize(
     }
 
     liveShare.onDidChangeSession(e => {
-        const liveShareProfile = config.getLiveShareProfile();
-        if (!liveShareProfile) {
-            return;
-        }
-
         if (e.session.id) {
+            const liveShareProfile = config.getLiveShareProfile();
+            if (!liveShareProfile) {
+                return;
+            }
+
             activateProfileHandler(liveShareProfile);
         } else {
-            restorePreviousProfile(config, activateProfileHandler);
+            const previousProfile = config.getPreviousProfile();
+            if (!previousProfile) {
+                return;
+            }
+
+            config.setPreviousProfile(undefined);
+            activateProfileHandler(previousProfile);
         }
     })
-}
-
-function restorePreviousProfile(
-    config: Config,
-    activateProfileHandler: (profile: string) => void
-) {
-    const previousProfile = config.getPreviousProfile();
-    if (!previousProfile) {
-        return;
-    }
-
-    config.setPreviousProfile(undefined);
-    activateProfileHandler(previousProfile);
 }


### PR DESCRIPTION
This PR introduces the notion of a "Live Share profile", which enables developers to automatically switch between profiles when they start a Live Share session. When you're hosting a Live Share session, your editor settings impact all guests in the session (but not your personalization settings!), and therefore, it could be valuable to have a profile that you use for collaboration, which is more amenable to your peers if you collaborate frequently (e.g. turning off auto-save/format on save/etc).

This could also allow activating extensions only when a Live Share session is active, which could be valuable when you want to use extensions that only contribute to Live Share (e.g. [whiteboard](aka.ms/vsls-whiteboard)).

Below is a demo gif that shows the `files.autoSave` setting being toggled automatically when starting and stopping a Live Share session:

![ProfileSwitcher](https://user-images.githubusercontent.com/116461/60541846-4dd8f580-9cc7-11e9-8b57-b8aca0252fb4.gif)