### PR TITLE
Support for workspace settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,8 +16,12 @@ async function activateProfile(
 
   await config.setCurrentProfile(profile);
 
-  let profileSettings = config.getProfileSettings(profile);
+  let configSettings = config.getProfileSettings(profile);
+  let profileSettings = await settingsHelper.getProfileSettings(profile, configSettings);
+  let workspaceSettings = await settingsHelper.getWorkspaceSettings(profile, Object.assign({}, configSettings));
+
   await settingsHelper.updateUserSettings(profileSettings);
+  await settingsHelper.updateWorkspaceSettings(workspaceSettings);
 
   let extensions = config.getProfileExtensions(profile);
   await extensionsHelper.installExtensions(extensions, logger);

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -27,6 +27,7 @@ class Config {
   public constructor(private context?: vscode.ExtensionContext) {}
 
   private getConfig() {
+    // has to be a dinstinction between pulling workspace configs and user configs
     return vscode.workspace.getConfiguration(ConfigKey);
   }
 


### PR DESCRIPTION
This isn't fully fleshed out, but it's got basic workspace setting support (didn't do extensions, but I'd imagine it could be set up in a similar fashion).

I didn't add any support for automatically adding settings to the workspace json, but if users manually add settings this should adhere to them when switching profiles.