### PR TITLE
modified updateUserSettings() to do a deep clone of settings.json

### DIFF
--- a/src/settingsHelper.ts
+++ b/src/settingsHelper.ts
@@ -122,7 +122,7 @@ export default class SettingsHelper {
   public async updateUserSettings(update: Settings): Promise<void> {
     const existingSettings = await this.getUserSettings();
 
-    const newSettings = Object.assign({}, existingSettings, update);
+    const newSettings = Object.assign({}, JSON.parse(JSON.stringify(existingSettings)), JSON.parse(JSON.stringify(update)));
 
     const settingsAsJson = JSON.stringify(newSettings, null, 4);
 


### PR DESCRIPTION
As it is, updateUserSettings() does not honor nested objects because of how Object.assign() works, only doing shallow copies of objects passed to it. By first turning the data into a string then back into JSON, objects like "workbench.colorCustomizations" should now be applied properly when selecting profiles. 

This should fix issues #27 & #23